### PR TITLE
Test/conversion actions 2v7qaz3

### DIFF
--- a/src/__tests__/popup/actions/conversion.actions.test.ts
+++ b/src/__tests__/popup/actions/conversion.actions.test.ts
@@ -1,0 +1,68 @@
+import { ActionType } from '@popup/actions/action-type.enum';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as convertionActions from 'src/popup/actions/conversion.actions';
+import HiveUtils from 'src/utils/hive.utils';
+import utilsT from 'src/__tests__/utils-for-testing/fake-data.utils';
+//configuring
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+//end configuring
+
+describe('conversion.actions tests:\n', () => {
+  describe('fetchConversionRequests tests:\n', () => {
+    test('Calling this action will return convertions from this user and a FETCH_CONVERSION_REQUESTS action', async () => {
+      const fakeArrayResponse = [
+        utilsT.fakeHbdConversionsResponse,
+        utilsT.fakeHiveConversionsResponse,
+      ];
+      const mockGetConvertionRequests = (HiveUtils.getConversionRequests = jest
+        .fn()
+        .mockResolvedValueOnce(fakeArrayResponse));
+      const mockedStore = mockStore({});
+      return await mockedStore
+        .dispatch<any>(
+          convertionActions.fetchConversionRequests(utilsT.userData.username),
+        )
+        .then(() => {
+          expect(mockedStore.getActions()).toEqual([
+            {
+              type: ActionType.FETCH_CONVERSION_REQUESTS,
+              payload: fakeArrayResponse,
+            },
+          ]);
+          expect(mockGetConvertionRequests).toBeCalledTimes(1);
+          expect(mockGetConvertionRequests).toBeCalledWith(
+            utilsT.userData.username,
+          );
+          mockGetConvertionRequests.mockReset();
+          mockGetConvertionRequests.mockRestore();
+        });
+    });
+    test('If an error occurs on the request, will thrown a unhandled error', async () => {
+      const errorRequest = new Error('Custom Error');
+      const mockGetConvertionRequests = (HiveUtils.getConversionRequests = jest
+        .fn()
+        .mockRejectedValueOnce(errorRequest));
+      const mockedStore = mockStore({});
+      try {
+        return await mockedStore
+          .dispatch<any>(
+            convertionActions.fetchConversionRequests(utilsT.userData.username),
+          )
+          .then(() => {
+            expect(mockedStore.getActions()).toEqual([
+              {
+                type: ActionType.FETCH_CONVERSION_REQUESTS,
+                payload: '',
+              },
+            ]);
+            mockGetConvertionRequests.mockReset();
+            mockGetConvertionRequests.mockRestore();
+          });
+      } catch (error) {
+        expect(error).toEqual(errorRequest);
+      }
+    });
+  });
+});

--- a/src/__tests__/popup/actions/conversion.actions.test.ts
+++ b/src/__tests__/popup/actions/conversion.actions.test.ts
@@ -1,65 +1,39 @@
-import { ActionType } from '@popup/actions/action-type.enum';
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import * as convertionActions from 'src/popup/actions/conversion.actions';
 import HiveUtils from 'src/utils/hive.utils';
 import utilsT from 'src/__tests__/utils-for-testing/fake-data.utils';
-//configuring
-const middlewares = [thunk];
-const mockStore = configureMockStore(middlewares);
-//end configuring
+import { getFakeStore } from 'src/__tests__/utils-for-testing/fake-store';
+import { initialEmptyStateStore } from 'src/__tests__/utils-for-testing/initial-states';
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
 describe('conversion.actions tests:\n', () => {
   describe('fetchConversionRequests tests:\n', () => {
-    test('Calling this action will return convertions from this user and a FETCH_CONVERSION_REQUESTS action', async () => {
+    test('Must set conversions', async () => {
       const fakeArrayResponse = [
         utilsT.fakeHbdConversionsResponse,
         utilsT.fakeHiveConversionsResponse,
       ];
-      const mockGetConvertionRequests = (HiveUtils.getConversionRequests = jest
+      HiveUtils.getConversionRequests = jest
         .fn()
-        .mockResolvedValueOnce(fakeArrayResponse));
-      const mockedStore = mockStore({});
-      return await mockedStore
-        .dispatch<any>(
-          convertionActions.fetchConversionRequests(utilsT.userData.username),
-        )
-        .then(() => {
-          expect(mockedStore.getActions()).toEqual([
-            {
-              type: ActionType.FETCH_CONVERSION_REQUESTS,
-              payload: fakeArrayResponse,
-            },
-          ]);
-          expect(mockGetConvertionRequests).toBeCalledTimes(1);
-          expect(mockGetConvertionRequests).toBeCalledWith(
-            utilsT.userData.username,
-          );
-          mockGetConvertionRequests.mockReset();
-          mockGetConvertionRequests.mockRestore();
-        });
+        .mockResolvedValueOnce(fakeArrayResponse);
+      const fakeStore = getFakeStore(initialEmptyStateStore);
+      await fakeStore.dispatch<any>(
+        convertionActions.fetchConversionRequests('wesp05'),
+      );
+      expect(fakeStore.getState().conversions).toEqual(fakeArrayResponse);
     });
     test('If an error occurs on the request, will thrown a unhandled error', async () => {
       const errorRequest = new Error('Custom Error');
-      const mockGetConvertionRequests = (HiveUtils.getConversionRequests = jest
+      HiveUtils.getConversionRequests = jest
         .fn()
-        .mockRejectedValueOnce(errorRequest));
-      const mockedStore = mockStore({});
+        .mockRejectedValueOnce(errorRequest);
       try {
-        return await mockedStore
-          .dispatch<any>(
-            convertionActions.fetchConversionRequests(utilsT.userData.username),
-          )
-          .then(() => {
-            expect(mockedStore.getActions()).toEqual([
-              {
-                type: ActionType.FETCH_CONVERSION_REQUESTS,
-                payload: '',
-              },
-            ]);
-            mockGetConvertionRequests.mockReset();
-            mockGetConvertionRequests.mockRestore();
-          });
+        const fakeStore = getFakeStore(initialEmptyStateStore);
+        await fakeStore.dispatch<any>(
+          convertionActions.fetchConversionRequests('wesp05'),
+        );
+        expect(fakeStore.getState().conversions).toEqual(null);
       } catch (error) {
         expect(error).toEqual(errorRequest);
       }

--- a/src/popup/actions/conversion.actions.ts
+++ b/src/popup/actions/conversion.actions.ts
@@ -1,11 +1,11 @@
 import { ActionType } from '@popup/actions/action-type.enum';
 import { AppThunk } from '@popup/actions/interfaces';
-import { getConversionRequests } from 'src/utils/hive.utils';
+import HiveUtils from 'src/utils/hive.utils';
 
 export const fetchConversionRequests =
   (name: string): AppThunk =>
   async (dispatch) => {
-    const conversions = await getConversionRequests(name);
+    const conversions = await HiveUtils.getConversionRequests(name); //modified for testing
     dispatch({
       type: ActionType.FETCH_CONVERSION_REQUESTS,
       payload: conversions,


### PR DESCRIPTION
Tests working locally, mocking third party to ensure testing local scope.
Mocks & Spies:
- HiveUtils.getConversionRequests

Note: There is one case that may lead to a bigger error. 
 -Case #2: If an error occurs on the request, will thrown a unhandled error 
_If this is not important, ignore it as in the test the error is being handled, but if it is important, consider adding a handler for this case._

- Modified one line of code inside the function for testing:
`HiveUtils.getConversionRequests(name); //modified for testing  `