### PR TITLE
rpc-utils: Replace relative default URL by absolute URL.

### DIFF
--- a/src/__tests__/utils/rpc.utils.test.ts
+++ b/src/__tests__/utils/rpc.utils.test.ts
@@ -190,7 +190,7 @@ describe('rpc.utils tests:\n', () => {
         .mockResolvedValueOnce(fakeResponse);
       expect(await RpcUtils.checkRpcStatus('DEFAULT')).toBe(true);
       expect(spyAxiosGet).toBeCalledTimes(1);
-      expect(spyAxiosGet).toBeCalledWith('api.hive.blog/health');
+      expect(spyAxiosGet).toBeCalledWith('https://api.hive.blog/health');
     });
     test('Checking on a hardcoded uri, will check on "uri/health" and return status', async () => {
       const spyAxiosGet = jest

--- a/src/utils/rpc.utils.ts
+++ b/src/utils/rpc.utils.ts
@@ -73,7 +73,7 @@ const checkRpcStatus = async (uri: string) => {
     },
   );
   try {
-    await axios.get(`${uri === 'DEFAULT' ? 'api.hive.blog' : uri}/health`);
+    await axios.get(`${uri === 'DEFAULT' ? 'https://api.hive.blog' : uri}/health`);
     return true;
   } catch (err) {
     Logger.error(err);


### PR DESCRIPTION
While playing around, I ran into some failing requests to `<myserver>/api.hive.blog/health`. This should fix the most direct cause, afaics