### PR TITLE
Move keychanify check to stop unnecessary changes

### DIFF
--- a/src/content-scripts/keychainify/index.ts
+++ b/src/content-scripts/keychainify/index.ts
@@ -43,31 +43,36 @@ let contentScript: Props = {
     initObserver: function () {
       let body = document.body;
 
-      // Using a MutationObserver to wait for a DOM change
-      // This is to scan dynamically loaded content (lazyload of comments for example)
-      contentScript.process.observer = new MutationObserver(
-        (function (process) {
-          return function (mutations: MutationRecord[]) {
-            mutations.forEach(function () {
-              // Preventing multiple calls to checkAnchors()
-              if (process.observerTimer) {
-                window.clearTimeout(process.observerTimer);
-              }
+      keychainify.isKeychainifyEnabled().then((enabled) => {
+        if (!enabled) {
+          return;
+        }
+        // Using a MutationObserver to wait for a DOM change
+        // This is to scan dynamically loaded content (lazyload of comments for example)
+        contentScript.process.observer = new MutationObserver(
+          (function (process) {
+            return function (mutations: MutationRecord[]) {
+              mutations.forEach(function () {
+                // Preventing multiple calls to checkAnchors()
+                if (process.observerTimer) {
+                  window.clearTimeout(process.observerTimer);
+                }
 
-              // Lets wait for a DOM change
-              process.observerTimer = window.setTimeout(function () {
-                process.checkAnchors();
-              }, 500);
-            });
-          };
-        })(contentScript.process),
-      );
+                // Lets wait for a DOM change
+                process.observerTimer = window.setTimeout(function () {
+                  process.checkAnchors();
+                }, 500);
+              });
+            };
+          })(contentScript.process),
+        );
 
-      // Waiting for the DOM to be modified (lazy loading)
-      contentScript.process.observer.observe(
-        body,
-        contentScript.process.observerConfig,
-      );
+        // Waiting for the DOM to be modified (lazy loading)
+        contentScript.process.observer.observe(
+          body,
+          contentScript.process.observerConfig,
+        );
+      });
     },
 
     /**
@@ -90,11 +95,7 @@ let contentScript: Props = {
             e.preventDefault();
             e.stopPropagation();
 
-            if (await keychainify.isKeychainifyEnabled()) {
-              keychainify.keychainifyUrl(this.href);
-            } else {
-              window.location.href = this.href;
-            }
+            keychainify.keychainifyUrl(this.href);
 
             return false;
           });


### PR DESCRIPTION
Keychanify invades all the webpages visited with ``keychanify_checked`` class, even though disabled in config. This is a quick fix that prevents MutationObserver from doing unnecessary work if keychanify is disabled.

This would still break pages with SSR when keychanify is enabled. So, eventually a better way of tagging elements is a must in my opinion.